### PR TITLE
Removed get from remoteConfig function

### DIFF
--- a/src/web.ts
+++ b/src/web.ts
@@ -217,7 +217,7 @@ export class FirebaseAnalyticsWeb extends WebPlugin
   /**
    * Returns analytics reference object
    */
-  get remoteConfig() {
+  remoteConfig() {
     return this.analyticsRef;
   }
 


### PR DESCRIPTION
Possibly this is not a bug. But it may pose a problem for users who have typescript 3.4.5.
It could be solved by updating typescript, but for this you have to update angular.
Doing that fixes the problem, but it can be a bit cumbersome having to update the project, especially if there are more dependencies.

I thought it would only have happened to me, but I've seen that I'm not the only one: [https://github.com/capacitor-community/firebase-analytics/issues/23](https://github.com/capacitor-community/firebase-analytics/issues/23)

Synchronizing the capacitor project:
````zsh
ERROR in ../node_modules/@capacitor-community/firebase-analytics/dist/esm/web.d.ts:90:9 - error TS1086: An accessor cannot be declared in an ambient context.

90     get remoteConfig(): any;
           ~~~~~~~~~~~~

[ERROR] An error occurred while running subprocess ng.
        
        ng run app:build exited with exit code 1.
        
        Re-running this command with the --verbose flag may provide more information.
````

Updating typescript:
````zsh
ERROR in The Angular Compiler requires TypeScript >=3.4.0 and <3.5.0 but 3.5.3 was found instead.
[ERROR] An error occurred while running subprocess ng.
````
