### PR TITLE
Fixed bug on android when setting user id

### DIFF
--- a/android/src/main/java/com/getcapacitor/community/firebaseanalytics/FirebaseAnalytics.java
+++ b/android/src/main/java/com/getcapacitor/community/firebaseanalytics/FirebaseAnalytics.java
@@ -53,6 +53,7 @@ public class FirebaseAnalytics extends Plugin {
 
       String userId = call.getString("userId");
       mFirebaseAnalytics.setUserId(userId);
+      call.success();
     } catch (Exception ex) {
       call.error(ex.getLocalizedMessage());
     }


### PR DESCRIPTION
While I was using this package, I found out when `setUserId` method is used with `await`, it is blocking code execution of further code when app is deployed on android.
Found out it was caused because caller of native method was not resolved after user id is set.
Providing PR to resolve this issue.