### PR TITLE
chore: proxy to logEvent() when setting screen name with setScreenName()

### DIFF
--- a/android/src/main/java/com/getcapacitor/community/firebaseanalytics/FirebaseAnalytics.java
+++ b/android/src/main/java/com/getcapacitor/community/firebaseanalytics/FirebaseAnalytics.java
@@ -147,11 +147,10 @@ public class FirebaseAnalytics extends Plugin {
 
             @Override
             public void run() {
-              mFirebaseAnalytics.setCurrentScreen(
-                bridge.getActivity(),
-                screenName,
-                nameOverride
-              );
+              Bundle bundle = new Bundle();
+              bundle.putString(FirebaseAnalytics.Param.SCREEN_NAME, screenName);
+              bundle.putString(FirebaseAnalytics.Param.SCREEN_CLASS, nameOverride);
+              mFirebaseAnalytics.logEvent(FirebaseAnalytics.Event.SCREEN_VIEW, bundle);
               call.success();
             }
           }

--- a/ios/Plugin/Plugin.swift
+++ b/ios/Plugin/Plugin.swift
@@ -73,7 +73,9 @@ public class FirebaseAnalytics: CAPPlugin {
         let nameOverride = call.getString("nameOverride") ?? nil
 
         DispatchQueue.main.async {
-            Analytics.setScreenName(screenName, screenClass: nameOverride)
+            Analytics.logEvent(AnalyticsEventScreenView,
+                parameters: [AnalyticsParameterScreenName: screenName,
+                             AnalyticsParameterScreenClass: nameOverride])
         }
         call.success()
     }


### PR DESCRIPTION
Previous methods of logging screen names using `setScreenName` on iOS and `setCurrentScreen` on Android wil be deprecated and removed in a future major release.