### PR TITLE
databaseUrl should not be required in config

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,8 +99,8 @@ git checkout -b firebase-analytics
 | logEvent                  | ✅      | ✅  | ✅  |
 | setCollectionEnabled      | ✅      | ✅  | ✅  |
 | setSessionTimeoutDuration | ✅      | ✅  | ✅  |
-| enable                    | ✅      | ✅  | ❌  |
-| disable                   | ✅      | ✅  | ❌  |
+| enable                    | ✅      | ✅  | ✅  |
+| disable                   | ✅      | ✅  | ✅  |
 
 ## Usage
 

--- a/src/definitions.ts
+++ b/src/definitions.ts
@@ -24,7 +24,7 @@ export interface FirebaseAnalyticsPlugin {
 export interface FirebaseInitOptions {
   apiKey: string;
   authDomain: string;
-  databaseURL: string;
+  databaseURL?: string;
   projectId: string;
   storageBucket: string;
   messagingSenderId: string;


### PR DESCRIPTION
I was trying to set up Firebase Analytics for the web using this plugin but I got a TypeScript error because I didn't provide a `databaseUrl`.  However, `databaseUrl` is not required for Firebase to function so it shouldn't be mandatory in the interface.