### PR TITLE
fix: stop passing deprecated config object when calling super()

### DIFF
--- a/src/web.ts
+++ b/src/web.ts
@@ -4,7 +4,8 @@ import { FirebaseAnalyticsPlugin, FirebaseInitOptions } from "./definitions";
 
 declare var window: any;
 
-export class FirebaseAnalyticsWeb extends WebPlugin
+export class FirebaseAnalyticsWeb
+  extends WebPlugin
   implements FirebaseAnalyticsPlugin {
   private not_supported_mssg = "This method is not supported";
   private options_missing_mssg = "Firebase options are missing";
@@ -28,11 +29,7 @@ export class FirebaseAnalyticsWeb extends WebPlugin
   ];
 
   constructor() {
-    super({
-      name: "FirebaseAnalytics",
-      platforms: ["web"],
-    });
-
+    super();
     this.ready = new Promise((resolve) => (this.readyResolver = resolve));
     this.configure();
   }


### PR DESCRIPTION
This information is now provided when calling registerPlugin()