### PR TITLE
Added rollup to the build command to generate support for CJS and UNP…

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20,6 +20,7 @@
         "prettier-plugin-java": "^0.8.0",
         "pretty-quick": "^3.1.0",
         "rimraf": "^3.0.2",
+        "rollup": "^2.29.0",
         "typescript": "^4.2.3"
       }
     },
@@ -1141,6 +1142,20 @@
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
       "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
       "dev": true
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
     },
     "node_modules/function-bind": {
       "version": "1.1.1",
@@ -3890,6 +3905,21 @@
         "rimraf": "bin.js"
       }
     },
+    "node_modules/rollup": {
+      "version": "2.50.0",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-2.50.0.tgz",
+      "integrity": "sha512-wO+F2MqWPGUCZx0549oqY8dsQqHVjuSxoyBWWnxKoQE+1UGcDKjtL7wHq/8jnnLJEeoGDQLf3ztrpgRwlbGJ0A==",
+      "dev": true,
+      "bin": {
+        "rollup": "dist/bin/rollup"
+      },
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.1"
+      }
+    },
     "node_modules/run-async": {
       "version": "2.4.1",
       "resolved": "https://registry.npmjs.org/run-async/-/run-async-2.4.1.tgz",
@@ -5443,6 +5473,13 @@
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
       "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
       "dev": true
+    },
+    "fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "optional": true
     },
     "function-bind": {
       "version": "1.1.1",
@@ -7615,6 +7652,15 @@
       "dev": true,
       "requires": {
         "glob": "^7.1.3"
+      }
+    },
+    "rollup": {
+      "version": "2.50.0",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-2.50.0.tgz",
+      "integrity": "sha512-wO+F2MqWPGUCZx0549oqY8dsQqHVjuSxoyBWWnxKoQE+1UGcDKjtL7wHq/8jnnLJEeoGDQLf3ztrpgRwlbGJ0A==",
+      "dev": true,
+      "requires": {
+        "fsevents": "~2.3.1"
       }
     },
     "run-async": {

--- a/package.json
+++ b/package.json
@@ -3,10 +3,12 @@
   "version": "1.0.0-alpha.5",
   "description": "A native plugin for firebase analytics.",
   "homepage": "https://github.com/capacitor-community/firebase-analytics",
-  "main": "dist/esm/index.js",
+  "main": "dist/plugin.cjs.js",
+  "module": "dist/esm/index.js",
   "types": "dist/esm/index.d.ts",
+  "unpkg": "dist/plugin.js",
   "scripts": {
-    "build": "npm run clean && tsc",
+    "build": "npm run clean && tsc && rollup -c rollup.config.js",
     "clean": "rimraf ./dist",
     "watch": "tsc --watch",
     "prepublishOnly": "npm run build",
@@ -27,6 +29,7 @@
     "prettier-plugin-java": "^0.8.0",
     "pretty-quick": "^3.1.0",
     "rimraf": "^3.0.2",
+    "rollup": "^2.29.0",
     "typescript": "^4.2.3"
   },
   "husky": {

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -1,14 +1,22 @@
-import nodeResolve from 'rollup-plugin-node-resolve';
-
 export default {
   input: 'dist/esm/index.js',
-  output: {
-    file: 'dist/plugin.js',
-    format: 'iife',
-    name: 'capacitorPlugin',
-    sourcemap: true
-  },
-  plugins: [
-    nodeResolve()
-  ]
+  output: [
+    {
+      file: 'dist/plugin.js',
+      format: 'iife',
+      name: 'capacitorPlugin',
+      globals: {
+        '@capacitor/core': 'capacitorExports',
+      },
+      sourcemap: true,
+      inlineDynamicImports: true,
+    },
+    {
+      file: 'dist/plugin.cjs.js',
+      format: 'cjs',
+      sourcemap: true,
+      inlineDynamicImports: true,
+    },
+  ],
+  external: ['@capacitor/core'],
 };


### PR DESCRIPTION
…KG, indirectly adding support for Browserify.

Had to correct the rollup.config.js file and made modifications to properly resolve capacitor core. Is now almost identical to official plugin's rollup configs.