### PR TITLE
Handle null instance ids

### DIFF
--- a/android/src/main/java/com/getcapacitor/community/firebaseanalytics/FirebaseAnalytics.java
+++ b/android/src/main/java/com/getcapacitor/community/firebaseanalytics/FirebaseAnalytics.java
@@ -119,7 +119,7 @@ public class FirebaseAnalytics extends Plugin {
         public void onComplete(@NonNull Task<String> task) {
             if (task.isSuccessful()) {
               String instanceId = task.getResult();
-              if (instanceId.isEmpty()) {
+              if (instanceId != null && instanceId.isEmpty()) {
                 call.reject("failed to obtain app instance id");
               } else {
                 JSObject result = new JSObject();

--- a/ios/Plugin/Plugin.swift
+++ b/ios/Plugin/Plugin.swift
@@ -51,7 +51,7 @@ public class FirebaseAnalytics: CAPPlugin {
     @objc func getAppInstanceId(_ call: CAPPluginCall) {
         let instanceId = Analytics.appInstanceID()
         call.resolve([
-            "instanceId": instanceId!
+            "instanceId": instanceId
         ])
     }
 

--- a/src/definitions.ts
+++ b/src/definitions.ts
@@ -2,7 +2,7 @@ export interface FirebaseAnalyticsPlugin {
   initializeFirebase(options: FirebaseInitOptions): Promise<any>;
   setUserId(options: { userId: string }): Promise<void>;
   setUserProperty(options: { name: string; value: string }): Promise<void>;
-  getAppInstanceId(): Promise<{ instanceId: string }>;
+  getAppInstanceId(): Promise<{ instanceId: string | null }>;
   setScreenName(options: {
     screenName: string;
     nameOverride?: string;


### PR DESCRIPTION
According to [Google's Documentation](https://developers.google.com/android/reference/com/google/firebase/analytics/FirebaseAnalytics), the value returned by the task spawned by `getAppInstanceId()` can be `null`. Currently, the plugin doesn't assume so and often casts the result to a non-nullable string. I added guards, removed casts and changed types in the Typescript definition