### PR TITLE
docs: update Android installation code

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,23 +63,12 @@ public class MainActivity extends BridgeActivity {
   @Override
   public void onCreate(Bundle savedInstanceState) {
     super.onCreate(savedInstanceState);
-
-    // Initializes the Bridge
-    this.init(
-        savedInstanceState,
-        new ArrayList<Class<? extends Plugin>>() {
-
-          {
-            // Additional plugins you've installed go here
-            // Ex: add(TotallyAwesomePlugin.class);
-            add(FirebaseAnalytics.class);
-          }
-        }
-      );
+    registerPlugin(FirebaseAnalytics.class);
   }
 }
-
 ```
+
+> **Note:** You may need to run **File > Sync Project with Gradle Files** in order for Android Studio to recognize the import.
 
 ## Configuration
 


### PR DESCRIPTION
While working with a Capacitor community member, we discovered that the installation steps for Android, when using Capacitor 3, were incorrect.

This pull request makes the following modifications to README.md:

1. The block of code under the Android installation step is updated using Capacitor 3's methodology.
2. A note is added under the code block conveying that you may need to sync the project with Gradle files for Android Studio to recognize the imported package.

Thanks to all who have contributed to this plugin and your contributions to the Capacitor Community! ❤️ 