### PR TITLE
removed explicit version of Firebase/Analytics pod

### DIFF
--- a/CapacitorCommunityFirebaseAnalytics.podspec
+++ b/CapacitorCommunityFirebaseAnalytics.podspec
@@ -12,5 +12,5 @@ Pod::Spec.new do |s|
     s.ios.deployment_target  = '12.0'
     s.static_framework = true
     s.dependency 'Capacitor'
-    s.dependency 'Firebase/Analytics', '~> 8.0'
+    s.dependency 'Firebase/Analytics'
   end

--- a/package-lock.json
+++ b/package-lock.json
@@ -6,7 +6,7 @@
   "packages": {
     "": {
       "name": "@capacitor-community/firebase-analytics",
-      "version": "1.0.1-alpha.0",
+      "version": "1.0.1",
       "license": "MIT",
       "dependencies": {
         "@capacitor/core": "^3.0.0"

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "build": "npm run clean && tsc && rollup -c rollup.config.js",
     "clean": "rimraf ./dist",
     "watch": "tsc --watch",
-    "prepublishOnly": "npm run build",
+    "prepublish": "npm run build",
     "release": "np",
     "test": "echo \"No test specified\""
   },


### PR DESCRIPTION
Using this plugin together with the latest `Firebase/Messaging` pod is currently not possible because this plugin fixes the version of `Firebase/Analytics` to `~> 8.0`. (latest version is 9.2.0)

When removing this fixed version, the used version can be defined more flexible.

If someone needs to use an older version of `Firebase/Analytics`, this is still possible by adding `pod 'Firebase/Analytics', '~> 8.0'` to the main `Podfile`